### PR TITLE
Only send color scheme to hardware if it has changed.

### DIFF
--- a/KSP-Chroma-Control/KSP-Chroma-Control/KSPChromaPlugin.cs
+++ b/KSP-Chroma-Control/KSP-Chroma-Control/KSPChromaPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 [assembly: CLSCompliant(false)]
 
@@ -25,6 +26,8 @@ namespace KspChromaControl
         private readonly ISceneManager flightSceneManager = new FlightSceneManager();
 
         private readonly ISceneManager vabSceneManager = new VabSceneManager();
+
+        private ColorScheme lastScheme = null;
 
         /// <summary>
         ///     Called by unity during the launch of this addon.
@@ -101,7 +104,21 @@ namespace KspChromaControl
                 }
             }
 
-            this.dataDrains.ForEach(drain => drain.Send(scheme));
+            bool update;
+            if (lastScheme == null)
+            {
+                update = true;
+            }
+            else
+            {
+                update = scheme.Count != lastScheme.Count || scheme.Except(lastScheme).Any();
+            }
+
+            if (update)
+            {
+                this.dataDrains.ForEach(drain => drain.Send(scheme));
+                lastScheme = scheme;
+            }
         }
     }
 }


### PR DESCRIPTION
This made my game boot super slowly and after digging into the code a bit it looks like the updates to the hardware take at least 60ms. This simply compares the last color scheme sent to the update to see if anything has changed before sending it to the hardware. I have almost literally zero experience with C# so feel free to critique it.